### PR TITLE
Matriz de covarianza

### DIFF
--- a/11-TP_Clasificacion.ipynb
+++ b/11-TP_Clasificacion.ipynb
@@ -313,7 +313,7 @@
     "\n",
     "Dato el conjunto de datos de entrenamiento $\\{x_1, \\dots, x_n\\}\\mid x_i \\in R^D$\n",
     "* Computar la media $\\bar{x}$ para cada dimensión y la matriz de covarianza $S$\n",
-    "$$\\bar{x}=\\frac{1}{N}\\sum_{n=1}^N x_n\\qquad S=\\frac{1}{N}\\sum_{n=1}^N(x_n-\\bar{x})^T(x_n-\\bar{x})$$\n",
+    "$$\\bar{x}=\\frac{1}{N}\\sum_{n=1}^N x_n\\qquad S=\\frac{1}{N-1}\\sum_{n=1}^N(x_n-\\bar{x})^T(x_n-\\bar{x})$$\n",
     "* Calcular los auto-valores $(\\lambda_i\\mid i\\in D)$ y auto-vectores $(u_i\\mid i\\in D)$ de la matriz de covarianza $S$\n",
     "* Ordenar los auto-vectores $u_i$ de manera decreciente con respecto a sus correspondientes auto-valores $\\lambda_i$.\n",
     "* Crear la matriz $U=(u_1,\\dots,u_D)$\n",


### PR DESCRIPTION
La formula de la matriz de covarianza en el algoritmo estaba mal, todo el calculo se divide por N-1, no por N

[Fuente: Wikipedia](https://es.wikipedia.org/wiki/An%C3%A1lisis_de_componentes_principales)
[Fuente: Paper](https://www.cs.cmu.edu/~elaw/papers/pca.pdf)